### PR TITLE
Add Repaste Module

### DIFF
--- a/assistant/__main__.py
+++ b/assistant/__main__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/assistant.py
+++ b/assistant/assistant.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/plugins/commands.py
+++ b/assistant/plugins/commands.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/plugins/inline.py
+++ b/assistant/plugins/inline.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/plugins/private.py
+++ b/assistant/plugins/private.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/plugins/repaste.py
+++ b/assistant/plugins/repaste.py
@@ -30,7 +30,7 @@ ENDPOINT = "https://nekobin.com/api/documents"
 ANSWER = "**Please use Nekobin for pastes.**\n"
 TIMEOUT = 3
 
-CHAT = Filters.chat(["PyrogramChat", "PyrogramLounge"])
+CHAT = Filters.chat("PyrogramChat")
 REGEX = Filters.regex(
     r"(https?://)?(www\.)?(?P<service>(p|h)astebin\.com|del\.dog)/(raw/)?(?P<tag>\w+)"
     # https://regex101.com/r/cl5iGU/2

--- a/assistant/plugins/repaste.py
+++ b/assistant/plugins/repaste.py
@@ -1,0 +1,73 @@
+# MIT License
+#
+# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import asyncio
+
+import aiohttp
+from pyrogram import Client, Filters, Message
+
+NEKO = "> nekobin.com/"
+ENDPOINT = "https://nekobin.com/api/documents"
+ANSWER = "**Please use Nekobin for pastes.**\n"
+TIMEOUT = 3
+
+CHAT = Filters.chat(["PyrogramChat", "PyrogramLounge"])
+REGEX = Filters.regex(
+    r"(https?://)?(www\.)?(?P<service>(p|h)astebin\.com|del\.dog)/(raw/)?(?P<tag>\w+)"
+    # https://regex101.com/r/cl5iGU/2
+)
+FILTER = REGEX & CHAT & ~Filters.edited
+
+
+async def get_and_post(paste_url: str):
+    """Get the pasted content from a paste service and repaste it to nekobin.
+    
+    Returns a `str` of the key saved on nekobin or an error code as `int`.
+    """
+    async with aiohttp.ClientSession() as session:
+        async with session.get(paste_url) as response:
+            try:
+                response.raise_for_status()
+            except aiohttp.ClientResponseError as error:
+                return error.status
+            payload = {"content": await response.text()}
+            post = await session.post(ENDPOINT, data=payload, timeout=TIMEOUT)
+            return (await post.json())["result"]["key"]
+
+
+async def reply_pastes(new_pastes: str, message: Message):
+    """Format a list of keys to a string and reply it."""
+    new_pastes = [NEKO + paste for paste in new_pastes if not isinstance(paste, int)]
+    if len(new_pastes) > 0:
+        await message.reply_text(
+            text=ANSWER + "\n".join(new_pastes), disable_web_page_preview=True,
+        )
+
+
+@Client.on_message(FILTER)
+async def catch_paste(app: Client, message: Message):
+    """Catch incoming pastes not on nekobin"""
+    new_pastes = [
+        await get_and_post(f"https://{match.group('service')}/raw/{match.group('tag')}")
+        for match in message.matches
+    ]
+    await reply_pastes(new_pastes, message)

--- a/assistant/plugins/repaste.py
+++ b/assistant/plugins/repaste.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/assistant/utils/docs.py
+++ b/assistant/utils/docs.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2019 Dan Tès <https://github.com/delivrance>
+# Copyright (c) 2020 Dan Tès <https://github.com/delivrance>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR adds a module to paste shared code to [Nekobin](https://nekobin.com/).

Currently supports Dogbin, Hastebin and Pastebin.

I've also taken the liberty to update the Copyright notice for the current year 2020.