### PR TITLE
Inline rules

### DIFF
--- a/assistant/plugins/commands.py
+++ b/assistant/plugins/commands.py
@@ -243,8 +243,9 @@ async def repost_rules(_, message: Message):
     if index == 0:
         index = 10
     split = RULES.split("\n")
-    text = f"{split[0]}\n\n{split[3:-3][index-1]}"
-    # -1 because we have a literal in the message, not a list index :D
+    text = f"{split[1]}\n\n{split[3:-3][index-1]}"
+    # First split index is a newline, thus using 1,
+    # also -1 because we have a literal in the message, not a list index :D
     await reply_and_delete(message, text)
 
 

--- a/assistant/plugins/inline.py
+++ b/assistant/plugins/inline.py
@@ -20,8 +20,10 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
+import textwrap
+
 from pyrogram import (
-    Emoji, InlineQuery, InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardButton,
+    Emoji, InlineQuery, InlineQueryResultArticle, InlineQueryResultPhoto, InputTextMessageContent, InlineKeyboardButton,
     InlineKeyboardMarkup, __version__
 )
 
@@ -34,6 +36,7 @@ CACHE_TIME = 5
 FIRE_THUMB = "https://i.imgur.com/qhYYqZa.png"
 ROCKET_THUMB = "https://i.imgur.com/PDaYHd8.png"
 OPEN_BOOK_THUMB = "https://i.imgur.com/v1XSJ1D.png"
+SCROLL_THUMB = "https://i.imgur.com/L1u0VlX.png"
 
 VERSION = __version__.split("-")[0]
 
@@ -234,6 +237,35 @@ async def inline(_, query: InlineQuery):
 
         for i in docs.RAW_TYPES[offset: offset + NEXT_OFFSET]:
             results.append(i[1])
+    elif string == "rules":
+        switch_pm_text = f"{Emoji.SCROLL} Chat Rules"
+
+        if offset == 0:
+            results.append(
+                InlineQueryResultArticle(
+                    title="Chat Rules",
+                    description="These are the rules for the Pyrogram Inn and the chats for other languages.",
+                    input_message_content=InputTextMessageContent(docs.rules),
+                    thumb_url=FIRE_THUMB,
+                )
+            )
+
+        for i in docs.RULES[offset: offset + NEXT_OFFSET]:
+            results.append(i)
+    elif string == "colin":
+        switch_pm_text = f"{Emoji.SHARK} Hidden Shark"
+
+        if offset == 0:
+            results.append(
+                InlineQueryResultPhoto(
+                    photo_url="https://i.imgur.com/f32hngs.jpg",
+                    # thumb_url="https://i.imgur.com/f32hngs.jpg",
+                    title="You found the secret Sharkception :O",
+                    description="You might not get anything from it, but you can feel proud to have found me!",
+                    caption=f"Hey, I found @ColinShark {Emoji.SHARK}",
+                    # input_message_content=InputTextMessageContent(f"Hey, I found @ColinShark {Emoji.SHARK}"),
+                )
+            )
 
     if results:
         await query.answer(
@@ -242,6 +274,7 @@ async def inline(_, query: InlineQuery):
             switch_pm_text=switch_pm_text,
             switch_pm_parameter="start",
             next_offset=str(offset + NEXT_OFFSET),
+            is_gallery=False
         )
     else:
         if offset:

--- a/assistant/plugins/inline.py
+++ b/assistant/plugins/inline.py
@@ -20,8 +20,6 @@
 #  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 #  SOFTWARE.
 
-import textwrap
-
 from pyrogram import (
     Emoji, InlineQuery, InlineQueryResultArticle, InlineQueryResultPhoto, InputTextMessageContent, InlineKeyboardButton,
     InlineKeyboardMarkup, __version__

--- a/assistant/utils/docs.py
+++ b/assistant/utils/docs.py
@@ -21,6 +21,7 @@
 #  SOFTWARE.
 
 import re
+import textwrap
 
 from pyrogram import (
     Emoji, InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton, Filters
@@ -274,6 +275,7 @@ ROCKET_THUMB = "https://i.imgur.com/PDaYHd8.png"
 ABOUT_BOT_THUMB = "https://i.imgur.com/zRglRz3.png"
 OPEN_BOOK_THUMB = "https://i.imgur.com/v1XSJ1D.png"
 RED_HEART_THUMB = "https://i.imgur.com/66FVFXz.png"
+SCROLL_THUMB = "https://i.imgur.com/L1u0VlX.png"
 
 HELP = (
     f"{Emoji.ROBOT_FACE} **Pyrogram Assistant**\n\n"
@@ -356,4 +358,31 @@ DEFAULT_RESULTS = [
         description="Ways to show your appreciation.",
         thumb_url=RED_HEART_THUMB,
     ),
+]
+
+rules = """
+**Pyrogram Rules**
+
+` 1.` English only. Other groups: #groups.
+` 2.` Spam, flood and hate speech is forbidden.
+` 3.` Talks unrelated to Pyrogram are not allowed.
+` 4.` Keep unrelated media/emojis to a minimum.
+` 5.` Be nice, respect people and use common sense.
+` 6.` Ask before sending PMs and respect answers.
+` 7.` \"Doesn't work\" means nothing. Explain in details.
+` 8.` Ask if you encounter errors, not if code is correct.
+` 9.` Make use of nekobin.com for sharing long code.
+`10.` No photos unless they are meaningful and small.
+
+__Rules are subject to change without notice.__
+"""
+
+RULES = [
+    InlineQueryResultArticle(
+        title=f"Rule {i}",
+        description=re.sub(r"` ?\d+.` ", "", rule),
+        input_message_content=InputTextMessageContent("**Pyrogram Rules**\n\n" + rule),
+        thumb_url=SCROLL_THUMB,
+    )
+    for i, rule in enumerate(rules.split("\n")[3:-3], 1)
 ]

--- a/assistant/utils/docs.py
+++ b/assistant/utils/docs.py
@@ -21,7 +21,6 @@
 #  SOFTWARE.
 
 import re
-import textwrap
 
 from pyrogram import (
     Emoji, InlineQueryResultArticle, InputTextMessageContent, InlineKeyboardMarkup, InlineKeyboardButton, Filters


### PR DESCRIPTION
Add the set of rules to be available as an inline result.

Usage: Start a message with `@pyrogrambot rules` and the rules should all appear. Sending the first results sends the full set into Chat, selecting one of the rules below sends this rule individually.

This PR also adds a new MessageHandler which filters individual rules to be reposted by the bot, as to not expose the initial sender (to prevent arguments from people replying to us).

I have also taken the opportunity and moved the rules to `docs.py`, as I believe they are better fit there and imported from a single place instead of having them duplicate in multiple places.