### PR TITLE
Add command #fmt

### DIFF
--- a/assistant/plugins/commands.py
+++ b/assistant/plugins/commands.py
@@ -331,6 +331,34 @@ async def rtfd(_, message: Message):
 ################################
 
 
+FORMATTING = (
+    "Please format your code with triple backticks to make it more readable.\n"
+    "<code>```your code here```</code>"
+)
+
+
+@Assistant.on_message(command("fmt"))
+@admins_only
+async def formatting(_, message: Message):
+    """Tell to format"""
+    await asyncio.gather(
+        message.delete(),
+        message.reply(
+            FORMATTING,
+            quote=False,
+            parse_mode="html"
+            disable_web_page_preview=True,
+            reply_to_message_id=getattr(
+                message.reply_to_message,
+                "message_id", None
+            ),
+        )
+    )
+
+
+################################
+
+
 DEV = (
     "The fix for this issue has already been pushed to the `develop` branch on "
     "[GitHub](https://github.com/pyrogram/pyrogram). You can now upgrade Pyrogram with:\n\n"

--- a/assistant/plugins/commands.py
+++ b/assistant/plugins/commands.py
@@ -241,8 +241,6 @@ async def rules(_, message: Message):
 )  # I know this is ugly, but this way we don't filter the full ruleset lol
 async def repost_rules(_, message: Message):
     index = int(message.text[17])
-    if index == 0:
-        index = 10
     split = RULES.split("\n")
     text = f"{split[1]}\n\n{split[3:-3][index - 1]}"
     # First split index is a newline, thus using 1,

--- a/assistant/utils/docs.py
+++ b/assistant/utils/docs.py
@@ -362,6 +362,7 @@ DEFAULT_RESULTS = [
 rules = """
 **Pyrogram Rules**
 
+` 0.` Follow rules to improve chances of getting answers.
 ` 1.` English only. Other groups: #groups.
 ` 2.` Spam, flood and hate speech is forbidden.
 ` 3.` Talks unrelated to Pyrogram are not allowed.
@@ -383,5 +384,5 @@ RULES = [
         input_message_content=InputTextMessageContent("**Pyrogram Rules**\n\n" + rule),
         thumb_url=SCROLL_THUMB,
     )
-    for i, rule in enumerate(rules.split("\n")[3:-3], 1)
+    for i, rule in enumerate(rules.split("\n")[3:-3])
 ]


### PR DESCRIPTION
Basically self-explanatory.

Adds a command to tell people to format their code using triple-backticked code block.